### PR TITLE
Use @thxnetwork/artifacts 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1423,12 +1423,6 @@
                 }
             }
         },
-        "@openzeppelin/contracts": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.5.0.tgz",
-            "integrity": "sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==",
-            "dev": true
-        },
         "@sindresorhus/is": {
             "version": "0.14.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -1529,9 +1523,9 @@
             }
         },
         "@thxnetwork/artifacts": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@thxnetwork/artifacts/-/artifacts-1.0.7.tgz",
-            "integrity": "sha512-wFIz71MXnewzCN4YeWCHnHsTtrDIhjc6TpfUx4bD0NC+5ct/3cjQqCoY5GSrWpIDkODvl5T88neuG+LIyGX+hQ=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@thxnetwork/artifacts/-/artifacts-2.0.0.tgz",
+            "integrity": "sha512-1gxkMXJEDKhY6AcfIA2pvVVTkAUvXJ0BRz7d7jZRb51+/KoeSn8qeT5oyx4twho9L5fjpuPcxx8E2A+glRsehg=="
         },
         "@toruslabs/customauth": {
             "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "lint": "vue-cli-service lint"
     },
     "dependencies": {
-        "@thxnetwork/artifacts": "^1.0.7",
+        "@thxnetwork/artifacts": "^2.0.0",
         "@toruslabs/customauth": "^6.0.1",
         "axios": "^0.21.2",
         "bootstrap": "^4.6.0",
@@ -72,7 +72,6 @@
         "web3": "^1.7.0"
     },
     "devDependencies": {
-        "@openzeppelin/contracts": "^4.4.2",
         "@types/chai": "^4.2.11",
         "@types/mocha": "^5.2.4",
         "@typescript-eslint/eslint-plugin": "^2.33.0",

--- a/src/store/modules/erc20.ts
+++ b/src/store/modules/erc20.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import Web3 from 'web3';
-import Artifacts from '@/utils/artifacts';
+import { contractConfig } from '@thxnetwork/artifacts';
 import { Contract } from 'web3-eth-contract';
 import { Action, Module, Mutation, VuexModule } from 'vuex-module-decorators';
 import { NetworkProvider } from '@/utils/network';
@@ -48,7 +48,8 @@ class ERC20Module extends VuexModule {
     async get({ web3, membership }: { web3: Web3; membership: Membership }) {
         try {
             const contract = new web3.eth.Contract(
-                Artifacts.IERC20.abi as any,
+                // Get latest (hardhat) config for abi of TokenLimitedSupply which is similar to ERC20
+                contractConfig('hardhat', 'TokenLimitedSupply').abi,
                 toChecksumAddress(membership.token.address),
             );
             const erc20 = new ERC20({

--- a/src/utils/artifacts.ts
+++ b/src/utils/artifacts.ts
@@ -1,7 +1,0 @@
-import IERC20 from '@thxnetwork/artifacts/artifacts/@openzeppelin/contracts/token/ERC20/IERC20.sol/IERC20.json';
-import IDefaultDiamond from '@thxnetwork/artifacts/artifacts/contracts/IDefaultDiamond.sol/IDefaultDiamond.json';
-
-export default {
-    IERC20,
-    IDefaultDiamond,
-};

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,8 +1,8 @@
 import Web3 from 'web3';
 import { isAddress } from 'web3-utils';
-import Artifacts from '@/utils/artifacts';
 import { Contract } from 'web3-eth-contract';
 import { soliditySha3 } from 'web3-utils';
+import { contractConfig, diamondAbi } from '@thxnetwork/artifacts';
 
 export const MINIMUM_GAS_LIMIT = 54680;
 export const MAX_UINT256 = '115792089237316195423570985008687907853269984665640564039457584007913129639935';
@@ -15,10 +15,10 @@ export enum NetworkProvider {
 export async function signCall(web3: Web3, poolAddress: string, name: string, params: any[], privateKey: string) {
     try {
         const account = web3.eth.accounts.privateKeyToAccount(privateKey);
-        const solution = new web3.eth.Contract(Artifacts.IDefaultDiamond.abi as any, poolAddress, {
+        const solution = new web3.eth.Contract(diamondAbi('hardhat', 'defaultPool') as any, poolAddress, {
             from: account.address,
         });
-        const abi: any = Artifacts.IDefaultDiamond.abi.find(fn => fn.name === name);
+        const abi: any = diamondAbi('hardhat', 'defaultPool').find(fn => fn.name === name);
         const nonce = Number(await solution.methods.getLatestNonce(account.address).call()) + 1;
         const call = web3.eth.abi.encodeFunctionCall(abi, params);
         const hash = soliditySha3(call, nonce) || '';
@@ -60,12 +60,12 @@ export async function send(web3: Web3, contract: Contract, fn: any, privateKey: 
 }
 
 export function getERC20Contract(web3: Web3, address: string) {
-    const abi: any = Artifacts.IERC20.abi;
+    const abi = contractConfig('hardhat', 'TokenLimitedSupply').abi;
     return new web3.eth.Contract(abi, address);
 }
 
 export function getAssetPoolContract(web3: Web3, address: string) {
-    const abi: any = Artifacts.IDefaultDiamond.abi;
+    const abi = diamondAbi('hardhat', 'defaultPool');
     return new web3.eth.Contract(abi, address);
 }
 


### PR DESCRIPTION
Since that module does not expose plain abi's we use the configs from the hardhat network since those should be most up to date.

Also there's no plain ERC20 abi but the one from the sample token is identical to ERC20.